### PR TITLE
Update lecture location, dates, and office hour schedules

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@
 title: INFO 1998
 email: jl3248@cornell.edu
 description: > # this means to ignore newlines until "baseurl:"
-  Introduction to Machine Learning for Python, Fall 2018
+  Introduction to Machine Learning for Python, Fall 2019
 baseurl: "/info1998" # the subpath of your site, e.g. /blog
 url: "cornelldatascience.github.io" # the base hostname & protocol for your site
 plugin:

--- a/index.md
+++ b/index.md
@@ -6,11 +6,7 @@ mainpage: true
 
 ## Overview
 ----------------------------------------------------------------------------------------
-INFO 1998 is a ten week, one credit, S/U only course. It runs from <b>September 19th</b> through <b>November 28th</b>, 2018.
-
-There are two important dates where the registrar is concerned:
-- Last day to add: <b>October 3rd</b>, 2018
-- Last day to drop: <b>October 17th</b>, 2018
+INFO 1998 is a ten week, one credit, S/U only course. It runs from <b>September 18th</b> through <b>November 27th</b>, 2019.
 
 The goal of this course is to provide you with a high-level exposure to a wide range of Data Science techniques and Machine Learning models. From the basics of getting your Jupyter environment setup, to manipulating and visualizing data, to building supervised and unsupervised models, this class aims to give you the base intuition and skillset to continue developing and working on ML projects. We hope you to exit the course with an understanding of how models and optimization techniques work, as well as have the confidence and tools to solve future problems (e.g. ones you did not encounter in this course) on your own.
 

--- a/syllabus.md
+++ b/syllabus.md
@@ -14,7 +14,8 @@ Location location: Kennedy B-11
 ----------------------------------------------------------------------------------------
 ### Staff and office hours
 
-TBD
+**Lecturer: Tanmay Bansal**
+- Office Hour TBD
 
 > #### Notice
 > Please don't e-mail any of the TAs directly, unless necessary. All questions / queries for help should be done in person during office hours, or on the course Piazza. If there is something urgent going on, we recommend emailing the course manager.

--- a/syllabus.md
+++ b/syllabus.md
@@ -23,7 +23,7 @@ Location location: Kennedy B-11
 - Office Hour TBD
 
 **TA: Camilo Cedeno-Tobon**
-- Office Hour TBD
+Tuesday: 3:00pm - 4:00pm, Rhodes 503
 
 **TA: Chris Elliott**
 - Office Hour TBD

--- a/syllabus.md
+++ b/syllabus.md
@@ -9,7 +9,7 @@ INFO 1998, Fall 2019
 
 Lecture time: Wed 5:30pm - 6:30pm
 
-Location location: Kennedy B-11
+Location: Kimball B11
 
 ----------------------------------------------------------------------------------------
 ### Staff and office hours

--- a/syllabus.md
+++ b/syllabus.md
@@ -5,38 +5,19 @@ layout: main
 
 ### Lecture and section information
 
-INFO 1998, Fall 2018
+INFO 1998, Fall 2019
 
 Lecture time: Wed 5:30pm - 6:30pm
 
-Location location: Gates G01
+Location location: Kennedy B-11
 
 ----------------------------------------------------------------------------------------
 ### Staff and office hours
 
-**Lecturer: Abby Beeler**
-- Wednesday: 8:00pm - 9:00pm, Gates G11
-
-**Lecturer: Ethan Cohen**
-- Thursday: 7:00pm - 8:00pm, Rhodes 402
+TBD
 
 > #### Notice
 > Please don't e-mail any of the TAs directly, unless necessary. All questions / queries for help should be done in person during office hours, or on the course Piazza. If there is something urgent going on, we recommend emailing the course manager.
-
-**TA: Ann Zhang**
-- Thursday: 7:00pm - 8:00pm, Rhodes 402
-
-**TA: Chris Elliott**
-- Friday: 2:00pm - 3:00pm, Gates G15
-
-**TA: Dylan Tsai**
-- Wednesday: 8:00pm - 9:00pm, Gates G11
-
-**TA: Shubhom Bhattacharya**
-- Friday: 2:00pm - 3:00pm, Gates G15
-
-**TA: Tanmay Bansal**
-- Friday: 2:00pm - 3:00pm, Gates G15
 
 ----------------------------------------------------------------------------------------
 ### Catalog description

--- a/syllabus.md
+++ b/syllabus.md
@@ -19,7 +19,20 @@ Location location: Kennedy B-11
 
 > #### Notice
 > Please don't e-mail any of the TAs directly, unless necessary. All questions / queries for help should be done in person during office hours, or on the course Piazza. If there is something urgent going on, we recommend emailing the course manager.
+**TA: Ang Jia Jiunn**
+- Office Hour TBD
 
+**TA: Camilo Cedeno-Tobon**
+- Office Hour TBD
+
+**TA: Chris Elliott**
+- Office Hour TBD
+
+**TA: Dylan Tsai**
+- Office Hour TBD
+
+**TA: Samantha Cobado**
+- Office Hour TBD
 ----------------------------------------------------------------------------------------
 ### Catalog description
 

--- a/syllabus.md
+++ b/syllabus.md
@@ -26,7 +26,7 @@ Thursday: 2:00pm - 3:00pm, Rhodes 503
 Tuesday: 3:00pm - 4:00pm, Rhodes 503
 
 **TA: Chris Elliott**
-- Office Hour TBD
+Wednesday: 2:00pm - 3:00pm, Rhodes 503
 
 **TA: Dylan Tsai**
 - Office Hour TBD

--- a/syllabus.md
+++ b/syllabus.md
@@ -29,7 +29,7 @@ Tuesday: 3:00pm - 4:00pm, Rhodes 503
 Wednesday: 2:00pm - 3:00pm, Rhodes 503
 
 **TA: Dylan Tsai**
-- Office Hour TBD
+Thursday: 6:00pm - 7:00pm, Rhodes 503
 
 **TA: Samantha Cobado**
 Wednesday: 2:00pm - 3:00pm, Rhodes 503

--- a/syllabus.md
+++ b/syllabus.md
@@ -20,7 +20,7 @@ Location: Kimball B11
 > #### Notice
 > Please don't e-mail any of the TAs directly, unless necessary. All questions / queries for help should be done in person during office hours, or on the course Piazza. If there is something urgent going on, we recommend emailing the course manager.
 **TA: Ang Jia Jiunn**
-- Office Hour TBD
+Thursday: 2:00pm - 3:00pm, Rhodes 503
 
 **TA: Camilo Cedeno-Tobon**
 Tuesday: 3:00pm - 4:00pm, Rhodes 503

--- a/syllabus.md
+++ b/syllabus.md
@@ -15,7 +15,7 @@ Location location: Kennedy B-11
 ### Staff and office hours
 
 **Lecturer: Tanmay Bansal**
-- Office Hour TBD
+- Thursday: 3:30pm - 4:30pm, Rhodes 503
 
 > #### Notice
 > Please don't e-mail any of the TAs directly, unless necessary. All questions / queries for help should be done in person during office hours, or on the course Piazza. If there is something urgent going on, we recommend emailing the course manager.

--- a/syllabus.md
+++ b/syllabus.md
@@ -32,7 +32,7 @@ Tuesday: 3:00pm - 4:00pm, Rhodes 503
 - Office Hour TBD
 
 **TA: Samantha Cobado**
-- Office Hour TBD
+Wednesday: 2:00pm - 3:00pm, Rhodes 503
 ----------------------------------------------------------------------------------------
 ### Catalog description
 


### PR DESCRIPTION
the website still says 2018 dates and locations which will confuse students. i've brought this up for a while now and no one has changed it, so here is a pull request that removes the inaccurate info. we can update the site once there is accurate info